### PR TITLE
histosol category added to emissions dict #5

### DIFF
--- a/src/cattle_lca/models.py
+++ b/src/cattle_lca/models.py
@@ -933,6 +933,7 @@ def create_emissions_dictionary(keys):
         "soil_organic_N_indirect",
         "soil_inorganic_N_direct",
         "soil_inorganic_N_indirect",
+        "soil_histosol_N_direct",
         "soil_N_direct",
         "soil_N_indirect",
         "soils_N2O",


### PR DESCRIPTION
# Description

Histosol category (N2O emissions from organic soils cultivation) was added to the emissions dict.

Fixes #5 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Example.py was run to ensure that it is working. 


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

